### PR TITLE
Introduce timestamps to the ingester and have storage sort entries before writing them out

### DIFF
--- a/appender/appender.go
+++ b/appender/appender.go
@@ -14,7 +14,7 @@ type Appender struct {
 }
 
 // HandleAppend processes a request to append a single entry to the logs.
-func (a *Appender) HandleAppend(entry string) error {
+func (a *Appender) HandleAppend(entry *storage.LogEntry) error {
 	// Make sure we have a chunk to write to.
 	if a.openChunk == nil {
 		chunk, err := a.Storage.CreateChunk()

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -1,9 +1,17 @@
 package ingester
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/log-yarder/yarder/discovery"
+	"github.com/log-yarder/yarder/storage"
+)
+
+const (
+	timestampKey = "timestamp"
 )
 
 // Ingester is the entry point for log entry ingestion. It fans the entries out
@@ -13,13 +21,46 @@ type Ingester struct {
 }
 
 // HandleIngest ingests a single log entry.
-func (i *Ingester) HandleIngest(entry string) error {
+func (i *Ingester) HandleIngest(rawEntry []byte) error {
+	entry, err := createEntry(rawEntry)
+	if err != nil {
+		return fmt.Errorf("unable to create entry from raw entry: %v", err)
+	}
+
 	// For now, just append to all appenders.
 	for i, appender := range i.Discovery.Appenders {
 		err := appender.HandleAppend(entry)
 		if err != nil {
-			return fmt.Errorf("unable call append on appender %d: %v", i, err)
+			return fmt.Errorf("unable to handle append on appender %d: %v", i, err)
 		}
 	}
 	return nil
+}
+
+func createEntry(rawEntry []byte) (*storage.LogEntry, error) {
+	var jsonMap map[string]interface{}
+	err := json.Unmarshal(rawEntry, &jsonMap)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to unmarshal json: %v", err)
+	}
+
+	value, ok := jsonMap[timestampKey]
+	if !ok {
+		return nil, fmt.Errorf("Could not find key %s in map", timestampKey)
+	}
+
+	timeString, ok := value.(string)
+	if !ok {
+		return nil, fmt.Errorf("Unable to interpret timestamp as string")
+	}
+
+	timestamp, err := strconv.ParseInt(timeString, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to convert %s to a timestamp", timeString)
+	}
+
+	return &storage.LogEntry{
+		Timestamp: time.Unix(timestamp, 0),
+		Raw:       rawEntry,
+	}, nil
 }

--- a/ingester/ingester.go
+++ b/ingester/ingester.go
@@ -3,7 +3,6 @@ package ingester
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/log-yarder/yarder/discovery"
 	"github.com/log-yarder/yarder/storage"
@@ -49,13 +48,13 @@ func createEntry(rawEntry []byte) (*storage.LogEntry, error) {
 		return nil, fmt.Errorf("could not find key %s in map", timestampKey)
 	}
 
-	timestamp, ok := value.(float64)
+	timestampMs, ok := value.(float64)
 	if !ok {
 		return nil, fmt.Errorf("unable to interpret timestamp as int64")
 	}
 
 	return &storage.LogEntry{
-		Timestamp: time.Unix(int64(timestamp), 0),
-		Raw:       rawEntry,
+		TimestampMs: int64(timestampMs),
+		Raw:         rawEntry,
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 		name := fmt.Sprintf("entry-%d", i)
 		entryBlob, err := json.Marshal(&entry{
 			Name:      name,
-			Timestamp: fmt.Sprintf("%d", time.Now().Unix()),
+			Timestamp: time.Now().Unix(),
 		})
 		if err != nil {
 			log.Panicf("failed to marshal json: %v", err)
@@ -61,5 +61,5 @@ func main() {
 // entry is used only to serialize test log entries to json.
 type entry struct {
 	Name      string `json:"name"`
-	Timestamp string `json:"timestamp"`
+	Timestamp int64  `json:"timestamp"`
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ const (
 func main() {
 	tmpDir, err := ioutil.TempDir("", "yarder-dev")
 	if err != nil {
-		log.Panicf(fmt.Sprintf("unable to create temp dir, %v", err))
+		log.Panicf("unable to create temp dir, %v", err)
 	}
 
 	diskStorage := &storage.DiskStorage{Path: tmpDir}
@@ -53,7 +53,7 @@ func main() {
 
 		err = ingester.HandleIngest(entryBlob)
 		if err != nil {
-			log.Panicf(fmt.Sprintf("failed to ingest entry [%s], %v", name, err))
+			log.Panicf("failed to ingest entry [%s], %v", name, err)
 		}
 	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -73,7 +73,6 @@ func (c *diskLogChunk) Close() error {
 	}
 	c.closed = true
 
-	// Sort all the entries by timestamp.
 	sort.Sort(ByTimestamp(c.entries))
 
 	// Write the raw file for this chunk before anything else.

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"path"
 	"sort"
-	"time"
 )
 
 const (
@@ -46,8 +45,8 @@ type persistedChunk struct {
 }
 
 type LogEntry struct {
-	Timestamp time.Time
-	Raw       []byte
+	TimestampMs int64
+	Raw         []byte
 }
 
 // diskLogChunk is an implementation of LogChunk backed by a directory on disk.
@@ -115,4 +114,4 @@ type ByTimestamp []*LogEntry
 
 func (t ByTimestamp) Len() int           { return len(t) }
 func (t ByTimestamp) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
-func (t ByTimestamp) Less(i, j int) bool { return t[i].Timestamp.Before(t[j].Timestamp) }
+func (t ByTimestamp) Less(i, j int) bool { return t[i].TimestampMs < t[j].TimestampMs }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSize(t *testing.T) {
+	storage := createStorage(t)
+	chunk, err := storage.CreateChunk()
+	require.NoError(t, err)
+
+	chunk.Append(&LogEntry{Timestamp: time.Unix(6, 0)})
+	chunk.Append(&LogEntry{Timestamp: time.Unix(4, 0)})
+	chunk.Append(&LogEntry{Timestamp: time.Unix(5, 0)})
+
+	require.Equal(t, 3, chunk.Size())
+}
+
+func TestSortsEntries(t *testing.T) {
+	storage := createStorage(t)
+	chunk, err := storage.CreateChunk()
+	require.NoError(t, err)
+
+	chunk.Append(&LogEntry{Timestamp: time.Unix(6, 0)})
+	chunk.Append(&LogEntry{Timestamp: time.Unix(4, 0)})
+	chunk.Append(&LogEntry{Timestamp: time.Unix(5, 0)})
+
+	err = chunk.Close()
+	require.NoError(t, err)
+
+	// TODO(dino): Add an actual read API to storage. For now, we use the fact
+	// that we are dealing with a file storage and use its path.
+	files, err := ioutil.ReadDir(storage.Path)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(files))
+
+	contents, err := ioutil.ReadFile(path.Join(storage.Path, files[0].Name()))
+	require.NoError(t, err)
+
+	var p persistedChunk
+	err = json.Unmarshal(contents, &p)
+	require.NoError(t, err)
+
+	// Check that the entries are in order.
+	require.Equal(t, 3, len(p.Entries))
+	require.Equal(t, time.Unix(4, 0), p.Entries[0].Timestamp)
+	require.Equal(t, time.Unix(5, 0), p.Entries[1].Timestamp)
+	require.Equal(t, time.Unix(6, 0), p.Entries[2].Timestamp)
+}
+
+func createStorage(t *testing.T) *DiskStorage {
+	tmpDir, err := ioutil.TempDir("", "yarder-dev")
+	require.NoError(t, err)
+	return &DiskStorage{Path: tmpDir}
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -11,6 +12,8 @@ import (
 
 func TestSize(t *testing.T) {
 	storage := createStorage(t)
+	defer os.RemoveAll(storage.Path)
+
 	chunk, err := storage.CreateChunk()
 	require.NoError(t, err)
 
@@ -23,6 +26,8 @@ func TestSize(t *testing.T) {
 
 func TestSortsEntries(t *testing.T) {
 	storage := createStorage(t)
+	defer os.RemoveAll(storage.Path)
+
 	chunk, err := storage.CreateChunk()
 	require.NoError(t, err)
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -15,9 +14,9 @@ func TestSize(t *testing.T) {
 	chunk, err := storage.CreateChunk()
 	require.NoError(t, err)
 
-	chunk.Append(&LogEntry{Timestamp: time.Unix(6, 0)})
-	chunk.Append(&LogEntry{Timestamp: time.Unix(4, 0)})
-	chunk.Append(&LogEntry{Timestamp: time.Unix(5, 0)})
+	chunk.Append(&LogEntry{TimestampMs: 6})
+	chunk.Append(&LogEntry{TimestampMs: 4})
+	chunk.Append(&LogEntry{TimestampMs: 5})
 
 	require.Equal(t, 3, chunk.Size())
 }
@@ -27,9 +26,9 @@ func TestSortsEntries(t *testing.T) {
 	chunk, err := storage.CreateChunk()
 	require.NoError(t, err)
 
-	chunk.Append(&LogEntry{Timestamp: time.Unix(6, 0)})
-	chunk.Append(&LogEntry{Timestamp: time.Unix(4, 0)})
-	chunk.Append(&LogEntry{Timestamp: time.Unix(5, 0)})
+	chunk.Append(&LogEntry{TimestampMs: 6})
+	chunk.Append(&LogEntry{TimestampMs: 4})
+	chunk.Append(&LogEntry{TimestampMs: 5})
 
 	err = chunk.Close()
 	require.NoError(t, err)
@@ -49,9 +48,9 @@ func TestSortsEntries(t *testing.T) {
 
 	// Check that the entries are in order.
 	require.Equal(t, 3, len(p.Entries))
-	require.Equal(t, time.Unix(4, 0), p.Entries[0].Timestamp)
-	require.Equal(t, time.Unix(5, 0), p.Entries[1].Timestamp)
-	require.Equal(t, time.Unix(6, 0), p.Entries[2].Timestamp)
+	require.Equal(t, int64(4), p.Entries[0].TimestampMs)
+	require.Equal(t, int64(5), p.Entries[1].TimestampMs)
+	require.Equal(t, int64(6), p.Entries[2].TimestampMs)
 }
 
 func createStorage(t *testing.T) *DiskStorage {


### PR DESCRIPTION
* Ingester now looks for a "timestamp" field in the processed blob
* The timestamp is added to the log entry
* Storage now sorts the log entries before writing them out to chunks
* Storage now has a unit test

In a follow-up, I will add test for ingester and appender, at which point we can remove the contents of main.go in favor of a more self-respecting binary.